### PR TITLE
Make Discord-populated fields read-only

### DIFF
--- a/prismbot/roles/admin.py
+++ b/prismbot/roles/admin.py
@@ -7,6 +7,7 @@ from .models import DiscordRole, RoleCategory
 class DiscordRoleAdmin(admin.ModelAdmin):
     model = DiscordRole
     list_display = ("name", "emoji", "category")
+    readonly_fields = ("discord_role_id", "name")
 
 
 @admin.register(RoleCategory)


### PR DESCRIPTION
Just a quick data integrity fix to prevent Discord Role names and discord IDs from being accidentally changed to something different than their Discord names—which might make them harder to manage. An upcoming update to Django's `Model.objects.bulk_create` will allow us to update already-existing role names during the same action, so especially once that feature is available there's really no need to be able to change Role names in the Django admin. And before then, a workaround would just be to delete the existing `DiscordRole` object and re-sync it.