### PR TITLE
Add role selection dialogues to slash command list

### DIFF
--- a/prismbot/bot/client.py
+++ b/prismbot/bot/client.py
@@ -1,9 +1,13 @@
+import logging
+
 import discord
 from discord.ext import commands
 from django.conf import settings
 
 DISCORD_GUILD = discord.Object(id=settings.DISCORD_GUILD_ID)
 INSTALLED_EXTENSIONS = ["prismbot.bot.commands.roles"]
+
+logger = logging.basicConfig(level=logging.DEBUG if settings.DEBUG else logging.INFO)
 
 
 class BotClient(commands.Bot):
@@ -27,7 +31,7 @@ class BotClient(commands.Bot):
         print("------")
 
 
-intents = discord.Intents.all()
+intents = discord.Intents.default()
 
 bot = BotClient(
     intents=intents, command_prefix="=", application_id=settings.DISCORD_APPLICATION_ID

--- a/prismbot/bot/commands/roles.py
+++ b/prismbot/bot/commands/roles.py
@@ -1,18 +1,150 @@
+import logging
+from enum import Enum
+from functools import partial
+from typing import Coroutine, Dict, List, Tuple
+
 import discord
+from asgiref.sync import sync_to_async
 from discord import app_commands
 from discord.ext import commands
+from discord.ui import Button, View
 
-from prismbot.roles.models import DiscordRole
+from prismbot.roles.models import DiscordRole, RoleCategory
+
+logger = logging.getLogger()
+
+
+class RoleButtonStyle(Enum):
+    ASSIGNED = discord.ButtonStyle.success.value
+    UNASSIGNED = discord.ButtonStyle.secondary.value
+
+
+class RoleAssignmentButton(Button):
+    def __init__(self, role: DiscordRole, member: discord.Member) -> None:
+        role_id = role.discord_role_id
+        style = (
+            RoleButtonStyle.ASSIGNED
+            if self.member_has_role(member, role)
+            else RoleButtonStyle.UNASSIGNED
+        )
+        super().__init__(
+            style=style, label=role.name, custom_id=str(role_id), emoji=role.emoji
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        member, role = self.interaction_member_and_role(interaction)
+        has_role = self.member_has_role(member, role)
+        try:
+            if has_role:
+                await member.remove_roles(
+                    role, reason="Member removed role from themself"
+                )
+                self.style = RoleButtonStyle.UNASSIGNED
+                logger.info(f"Removed role {role.name} from {member.display_name}")
+            else:
+                await member.add_roles(role, reason="Member self-assigned role")
+                self.style = RoleButtonStyle.ASSIGNED
+                logger.info(f"Added role {role.name} to {member.display_name}")
+        except (discord.errors.Forbidden, discord.errors.HTTPException) as error:
+            logger.error(f"Role assignment error: {error}")
+            return await interaction.response.send_message(
+                "I couldn't handle that for some reason. Could you try again?",
+                ephemeral=True,
+            )
+        return await interaction.response.edit_message(view=self.view)
+
+    def interaction_member_and_role(
+        self, interaction: discord.Interaction
+    ) -> Tuple[discord.Member, discord.Role]:
+        roles_by_id = self.guild_roles_by_id(interaction.guild.roles)
+        guild_role = roles_by_id.get(self.role_id())
+        return (interaction.user, guild_role)
+
+    def member_has_role(self, member, role) -> bool:
+        return role in member.roles
+
+    def guild_roles_by_id(self, guild_roles) -> Dict[str, discord.Role]:
+        return {role.id: role for role in guild_roles}
+
+    def role_id(self) -> str:
+        return int(self.custom_id)
+
+
+class RoleAssignmentView(View):
+    def __init__(
+        self,
+        category: RoleCategory,
+        member: discord.Member,
+        interaction: discord.Interaction,
+        timeout_callback: Coroutine,
+    ) -> None:
+        super().__init__(timeout=300)
+        self.member = member
+        self.interaction = interaction
+        self.timeout_callback = timeout_callback
+        self.populate(category, member)
+
+    def populate(self, category, member):
+        for role in category.discord_roles.all():
+            self.add_item(RoleAssignmentButton(role, member))
+
+    async def on_timeout(self) -> None:
+        logger.info(f"Timing out role view called by {self.member.display_name}")
+        await self.timeout_callback()
+        return await super().on_timeout()
 
 
 class Roles(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
+    @sync_to_async(thread_sensitive=False)
+    def get_assignable_categories(self) -> List[RoleCategory]:
+        return list(
+            RoleCategory.objects.filter(self_assignable=True)
+            .order_by("name")
+            .prefetch_related("discord_roles")
+        )
+
     @app_commands.command(
-        name="load-roles", description="Add existing roles to PrismBot's memory"
+        name="roles", description="Opens the role self-assignment dialogues"
     )
-    async def load_roles(self, interaction: discord.Interaction):
+    async def roles(self, interaction: discord.Interaction):
+        await interaction.response.send_message("Fetching roles...", ephemeral=True)
+        assignable_categories = await self.get_assignable_categories()
+        category_messages = []
+        clear_callback = partial(self.clear_messages, category_messages, interaction)
+        for category in assignable_categories:
+            category_view = RoleAssignmentView(
+                category=category,
+                member=interaction.user,
+                interaction=interaction,
+                timeout_callback=clear_callback,
+            )
+            category_webhook: discord.WebhookMessage = await interaction.followup.send(
+                category.message, view=category_view, ephemeral=True
+            )
+            await interaction.edit_original_message(
+                content="Role self-assignment options:"
+            )
+            category_messages.append(category_webhook)
+
+    async def clear_messages(
+        self, messages: List[discord.WebhookMessage], interaction: discord.Interaction
+    ):
+        for message in messages:
+            try:
+                await message.edit(content="Menu expired.", view=None)
+                await interaction.edit_original_message(
+                    content="The role menus have expired. Don't worry! Your changes have been saved. Type '/roles' again to reopen."
+                )
+            except Exception as error:
+                logger.warning(f"WebhookMessage deletion failed. Reason: {error}")
+
+    @app_commands.command(
+        name="refresh-roles", description="Add existing roles to PrismBot's memory"
+    )
+    async def refresh_roles(self, interaction: discord.Interaction):
         guild_roles = interaction.guild.roles
         roles_to_create = [
             DiscordRole(discord_role_id=role.id, name=role.name) for role in guild_roles

--- a/prismbot/roles/models.py
+++ b/prismbot/roles/models.py
@@ -39,7 +39,11 @@ class DiscordRole(models.Model):
         help_text="Emoji (unicode or discord emoji <name:id> tag) to associate with the Role; appears on signup buttons",
     )
     category = models.ForeignKey(
-        RoleCategory, blank=True, null=True, on_delete=models.SET_NULL
+        RoleCategory,
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name="discord_roles",
     )
 
     def __str__(self):


### PR DESCRIPTION
Resolves #1 

This update adds the `/roles` command to the slash commands menu, which will allow users to call up a role assignment message for each assignable category that exists in the database.

In order to sync the guild's roles to the database, an authorized user can use the '/refresh-roles' command, which will add all the roles not already present in the database. Then they can use the bot admin web UI to assign roles to role categories, set whether a category is self-assignable, add a message for the categories to accompany the self-assignment buttons, and optionally set emoji for each role.

The self-assignment menus will expire after 5 minutes. This is because whenever the bot shuts down or restarts, it will effectively abandon all the interactions it was previously managing—and this could be confusing to users who opened a menu before the bot restarted. With a timeout, the user will at least be notified that they'll need to run the command again to reopen the menus, and the chance anyone gets left hanging will be minimized.